### PR TITLE
SPARK-3883: Fixes after the review

### DIFF
--- a/conf/ssl.conf.template
+++ b/conf/ssl.conf.template
@@ -1,20 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 # Spark SSL settings
 
 # ssl.enabled               true
@@ -24,4 +7,4 @@
 # ssl.trustStore            /path/to/your/trustStore
 # ssl.trustStorePassword    password
 # ssl.enabledAlgorithms     [TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA]
-# ssl.protocol              SSLv3
+# ssl.protocol              TLSv1.2

--- a/core/src/test/resources/bad-ssl.conf
+++ b/core/src/test/resources/bad-ssl.conf
@@ -24,4 +24,4 @@ ssl.keyPassword           password
 ssl.trustStore            truststore
 ssl.trustStorePassword    password
 ssl.enabledAlgorithms     [TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA]
-ssl.protocol              SSLv3
+ssl.protocol              TLSv1.2

--- a/core/src/test/resources/good-ssl.conf
+++ b/core/src/test/resources/good-ssl.conf
@@ -24,4 +24,4 @@ ssl.keyPassword           password
 ssl.trustStore            truststore
 ssl.trustStorePassword    password
 ssl.enabledAlgorithms     [TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA]
-ssl.protocol              SSLv3
+ssl.protocol              TLSv1.2


### PR DESCRIPTION
- Removed license header from ssl.conf.template
- Fixed parameters order in SSLOptions.parse invocation in SecurityManager at L199
- Replaced org.apache.commons.io with different approaches
- Removed unused line of code from SecurityManager
- Changed the default protocol from SSLv3 to TLSv1.2 (POODLE attack)
